### PR TITLE
Surface `spiffe-go` SDK logs to user

### DIFF
--- a/cmd/credential_file.go
+++ b/cmd/credential_file.go
@@ -49,6 +49,7 @@ func oneshotX509CredentialFile(
 	client, err := workloadapi.New(
 		ctx,
 		workloadapi.WithAddr(sf.workloadAPIAddr),
+		workloadapi.WithLogger(internal.NewSPIFFESlogAdapter(slog.Default())),
 	)
 	if err != nil {
 		return fmt.Errorf("creating workload api client: %w", err)
@@ -144,6 +145,7 @@ func daemonX509CredentialFile(
 	client, err := workloadapi.New(
 		ctx,
 		workloadapi.WithAddr(sf.workloadAPIAddr),
+		workloadapi.WithLogger(internal.NewSPIFFESlogAdapter(slog.Default())),
 	)
 	if err != nil {
 		return fmt.Errorf("creating workload api client: %w", err)

--- a/cmd/credential_process.go
+++ b/cmd/credential_process.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spiffe/aws-spiffe-workload-helper/internal"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
@@ -21,6 +22,7 @@ func newX509CredentialProcessCmd() (*cobra.Command, error) {
 			client, err := workloadapi.New(
 				ctx,
 				workloadapi.WithAddr(sf.workloadAPIAddr),
+				workloadapi.WithLogger(internal.NewSPIFFESlogAdapter(slog.Default())),
 			)
 			if err != nil {
 				return fmt.Errorf("creating workload api client: %w", err)

--- a/internal/spiffe_log_bridge.go
+++ b/internal/spiffe_log_bridge.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spiffe/go-spiffe/v2/logger"
+)
+
+var _ logger.Logger = (*SPIFFESlogAdapter)(nil)
+
+// SPIFFESlogAdapter allows a slog logger to be injected into the SPIFFE GO
+// SDK.
+type SPIFFESlogAdapter struct {
+	slog *slog.Logger
+}
+
+func NewSPIFFESlogAdapter(slog *slog.Logger) SPIFFESlogAdapter {
+	return SPIFFESlogAdapter{slog: slog}
+}
+
+func (w SPIFFESlogAdapter) Debugf(format string, args ...interface{}) {
+	w.slog.Debug(fmt.Sprintf(format, args...))
+}
+
+func (w SPIFFESlogAdapter) Infof(format string, args ...interface{}) {
+	w.slog.Info(fmt.Sprintf(format, args...))
+}
+
+func (w SPIFFESlogAdapter) Warnf(format string, args ...interface{}) {
+	w.slog.Warn(fmt.Sprintf(format, args...))
+}
+
+func (w SPIFFESlogAdapter) Errorf(format string, args ...interface{}) {
+	w.slog.Error(fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
Logs from the internals of the `spiffe-go` SDK were not being propagated the Slog logger used by the rest of the implementation. This meant that in certain failure scenarios, it appeared that `aws-spiffe-workload-helper` was hanging - when in fact, it was silently retrying a failed action in the background. This should help with diagnostics/troubleshooting, although, it's a little frustrating that `spiffe-go` does not output structured logs :(